### PR TITLE
Add onboarding and daily tips

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Proyecto creado y mantenido por **[Jorge Marroquín](https://github.com/GrullonD
 - Registro rápido de ingresos y gastos
 - Visualización de reportes y gráficos interactivos
 - Categorías personalizables para tus transacciones
+- Consejos financieros diarios integrados
+- Onboarding educativo para nuevos usuarios
 - Interfaz intuitiva, profesional y responsiva
 - Soporte multiplataforma: **Android** e **iOS**
 - Persistencia local con Hive

--- a/lib/features/dashboard/page/dashboard_layout.dart
+++ b/lib/features/dashboard/page/dashboard_layout.dart
@@ -8,6 +8,7 @@ import 'package:personal_finance/features/data/model/expense.dart';
 import 'package:personal_finance/features/data/model/income.dart';
 import 'package:provider/provider.dart';
 import 'package:syncfusion_flutter_charts/charts.dart';
+import 'package:personal_finance/features/tips/tip_card.dart';
 
 class DashboardLayout extends StatelessWidget {
   const DashboardLayout({super.key});
@@ -60,6 +61,8 @@ class DashboardLayout extends StatelessWidget {
                     child: SingleChildScrollView(
                       child: Column(
                         children: <Widget>[
+                          const TipCard(),
+                          const SizedBox(height: 16),
                           BalanceCard(balance: logic.balance),
                           const SizedBox(height: 16),
                           PeriodSelector(

--- a/lib/features/home.dart
+++ b/lib/features/home.dart
@@ -50,7 +50,7 @@ class MyHomePage extends StatelessWidget {
       width: double.infinity,
       child: ElevatedButton(
         onPressed:
-            () => Navigator.pushReplacementNamed(context, RoutePath.login),
+            () => Navigator.pushReplacementNamed(context, RoutePath.onboarding),
         style: ElevatedButton.styleFrom(
           padding: const EdgeInsets.symmetric(vertical: 16),
           backgroundColor: Colors.deepPurple,

--- a/lib/features/onboarding/onboarding_page.dart
+++ b/lib/features/onboarding/onboarding_page.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/material.dart';
+import 'package:personal_finance/utils/routes/route_path.dart';
+
+class OnboardingPage extends StatefulWidget {
+  const OnboardingPage({super.key});
+
+  @override
+  State<OnboardingPage> createState() => _OnboardingPageState();
+}
+
+class _OnboardingPageState extends State<OnboardingPage> {
+  final PageController _controller = PageController();
+  int _index = 0;
+
+  final List<_OnboardStep> _steps = const <_OnboardStep>[
+    _OnboardStep(title: 'Registra tus gastos', description: 'Añade transacciones de forma rápida y sencilla.'),
+    _OnboardStep(title: 'Visualiza tu progreso', description: 'Consulta tu balance diario, semanal o mensual.'),
+    _OnboardStep(title: 'Aprende consejos', description: 'Recibe tips financieros personalizados cada día.'),
+  ];
+
+  @override
+  Widget build(BuildContext context) => Scaffold(
+        body: SafeArea(
+          child: Column(
+            children: <Widget>[
+              Expanded(
+                child: PageView.builder(
+                  controller: _controller,
+                  onPageChanged: (int i) => setState(() => _index = i),
+                  itemCount: _steps.length,
+                  itemBuilder: (BuildContext context, int i) {
+                    final _OnboardStep step = _steps[i];
+                    return Padding(
+                      padding: const EdgeInsets.all(24),
+                      child: Column(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: <Widget>[
+                          Icon(Icons.savings, size: 80, color: Theme.of(context).colorScheme.primary),
+                          const SizedBox(height: 20),
+                          Text(step.title, style: Theme.of(context).textTheme.headlineSmall, textAlign: TextAlign.center),
+                          const SizedBox(height: 12),
+                          Text(step.description, textAlign: TextAlign.center),
+                        ],
+                      ),
+                    );
+                  },
+                ),
+              ),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
+                child: Row(
+                  children: <Widget>[
+                    if (_index > 0)
+                      TextButton(
+                        onPressed: () {
+                          _controller.previousPage(duration: const Duration(milliseconds: 300), curve: Curves.easeInOut);
+                        },
+                        child: const Text('Atrás'),
+                      ),
+                    const Spacer(),
+                    ElevatedButton(
+                      onPressed: () {
+                        if (_index == _steps.length - 1) {
+                          Navigator.pushReplacementNamed(context, RoutePath.login);
+                        } else {
+                          _controller.nextPage(duration: const Duration(milliseconds: 300), curve: Curves.easeInOut);
+                        }
+                      },
+                      child: Text(_index == _steps.length - 1 ? 'Comenzar' : 'Siguiente'),
+                    )
+                  ],
+                ),
+              )
+            ],
+          ),
+        ),
+      );
+}
+
+class _OnboardStep {
+  final String title;
+  final String description;
+  const _OnboardStep({required this.title, required this.description});
+}

--- a/lib/features/tips/tip_card.dart
+++ b/lib/features/tips/tip_card.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import 'tip_provider.dart';
+
+class TipCard extends StatelessWidget {
+  const TipCard({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final String tip = context.watch<TipProvider>().todayTip;
+    final ThemeData theme = Theme.of(context);
+    return Card(
+      elevation: 4,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+      child: Padding(
+        padding: const EdgeInsets.all(20),
+        child: Row(
+          children: <Widget>[
+            const Icon(Icons.lightbulb_outline, color: Colors.orange),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Text(
+                tip,
+                style: theme.textTheme.bodyMedium?.copyWith(fontStyle: FontStyle.italic),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/tips/tip_provider.dart
+++ b/lib/features/tips/tip_provider.dart
@@ -1,0 +1,20 @@
+import 'dart:math';
+
+import 'package:flutter/material.dart';
+
+/// Simple provider to deliver daily financial tips.
+class TipProvider extends ChangeNotifier {
+  TipProvider();
+
+  final List<String> _tips = <String>[
+    'Ahorra al menos el 10% de cada ingreso que recibas.',
+    'Registra tus gastos diariamente para detectar hábitos.',
+    'Establece metas de ahorro mensuales realistas.',
+    'Evita compras impulsivas esperando 24 horas antes de decidir.',
+    'Revisa tus suscripciones y cancela las que no uses.',
+  ];
+
+  late final String _todayTip = _tips[Random(DateTime.now().day).nextInt(_tips.length)];
+
+  String get todayTip => _todayTip;
+}

--- a/lib/utils/app.dart
+++ b/lib/utils/app.dart
@@ -4,6 +4,7 @@ import 'package:google_fonts/google_fonts.dart';
 import 'package:personal_finance/features/auth/domain/auth_repository.dart';
 import 'package:personal_finance/features/auth/logic/auth_provider.dart';
 import 'package:personal_finance/features/dashboard/logic/dashboard_logic.dart';
+import 'package:personal_finance/features/tips/tip_provider.dart';
 import 'package:personal_finance/utils/app_localization.dart';
 import 'package:personal_finance/utils/injection_container.dart';
 import 'package:personal_finance/utils/routes/route_path.dart';
@@ -25,6 +26,7 @@ class MyApp extends StatelessWidget {
               ),
         ),
         ChangeNotifierProvider<DashboardLogic>(create: (_) => DashboardLogic()),
+        ChangeNotifierProvider<TipProvider>(create: (_) => TipProvider()),
       ],
       child: MaterialApp(
         title: 'Finanzas Personales',

--- a/lib/utils/routes/route_path.dart
+++ b/lib/utils/routes/route_path.dart
@@ -1,5 +1,6 @@
 class RoutePath {
   static const String home = '/';
+  static const String onboarding = '/onboarding';
   static const String login = '/login';
   static const String splash = '/splash';
   static const String dashboard = '/dashboard';

--- a/lib/utils/routes/route_switch.dart
+++ b/lib/utils/routes/route_switch.dart
@@ -4,6 +4,7 @@ import 'package:personal_finance/features/auth/pages/auth_page.dart';
 import 'package:personal_finance/features/dashboard/page/dashboard_page.dart';
 import 'package:personal_finance/features/dashboard/widgets/add_expense_modal.dart';
 import 'package:personal_finance/features/home.dart';
+import 'package:personal_finance/features/onboarding/onboarding_page.dart';
 import 'package:personal_finance/utils/routes/route_path.dart';
 
 class RouteSwitch {
@@ -15,6 +16,8 @@ class RouteSwitch {
         return MaterialPageRoute(builder: (BuildContext _) => const DashboardPage());
       case RoutePath.addExpense:
         return MaterialPageRoute(builder: (BuildContext _) => const AddExpenseModal());
+      case RoutePath.onboarding:
+        return MaterialPageRoute(builder: (BuildContext _) => const OnboardingPage());
       case RoutePath.login:
         return MaterialPageRoute(builder: (BuildContext _) => const LoginPage());
       default:

--- a/test/tip_provider_test.dart
+++ b/test/tip_provider_test.dart
@@ -1,0 +1,9 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:personal_finance/features/tips/tip_provider.dart';
+
+void main() {
+  test('TipProvider returns a tip', () {
+    final TipProvider provider = TipProvider();
+    expect(provider.todayTip.isNotEmpty, true);
+  });
+}


### PR DESCRIPTION
## Summary
- introduce TipProvider and TipCard for daily financial tips
- show tips on the dashboard
- add onboarding screens with simple PageView
- wire onboarding route and update navigation
- register new providers and update README
- add basic unit test for TipProvider

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875dee644cc832f91e4385ec9d12f6c