### PR TITLE
Add localization support

### DIFF
--- a/lib/features/auth/pages/auth_layout.dart
+++ b/lib/features/auth/pages/auth_layout.dart
@@ -1,23 +1,24 @@
 import 'package:flutter/material.dart';
 
 import 'package:personal_finance/features/auth/widgets/social_buttons.dart';
+import 'package:personal_finance/utils/app_localization.dart';
 
 class LoginLayout extends StatelessWidget {
   const LoginLayout({super.key});
 
   @override
-  Widget build(BuildContext context) => const Center(
+  Widget build(BuildContext context) => Center(
     child: Padding(
-      padding: EdgeInsets.symmetric(horizontal: 24),
+      padding: const EdgeInsets.symmetric(horizontal: 24),
       child: Column(
         mainAxisAlignment: MainAxisAlignment.center,
         children: <Widget>[
           Text(
-            'Inicia sesión para continuar',
-            style: TextStyle(fontSize: 22, fontWeight: FontWeight.bold),
+            AppLocalizations.of(context)!.signInToContinue,
+            style: const TextStyle(fontSize: 22, fontWeight: FontWeight.bold),
           ),
-          SizedBox(height: 40),
-          SocialLoginButtons(),
+          const SizedBox(height: 40),
+          const SocialLoginButtons(),
         ],
       ),
     ),

--- a/lib/features/auth/widgets/social_buttons.dart
+++ b/lib/features/auth/widgets/social_buttons.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:personal_finance/features/auth/logic/auth_provider.dart';
+import 'package:personal_finance/utils/app_localization.dart';
 import 'package:provider/provider.dart';
 
 class SocialLoginButtons extends StatelessWidget {
@@ -27,7 +28,7 @@ class SocialLoginButtons extends StatelessWidget {
               width: double.infinity,
               child: ElevatedButton.icon(
                 icon: const Icon(Icons.g_mobiledata),
-                label: const Text('Continuar con Google'),
+                label: Text(AppLocalizations.of(context)!.continueWithGoogle),
                 onPressed:
                     provider.isLoading
                         ? null
@@ -49,7 +50,7 @@ class SocialLoginButtons extends StatelessWidget {
                 width: double.infinity,
                 child: ElevatedButton.icon(
                   icon: const Icon(Icons.apple),
-                  label: const Text('Continuar con Apple'),
+                  label: Text(AppLocalizations.of(context)!.continueWithApple),
                   onPressed:
                       provider.isLoading
                           ? null

--- a/lib/features/dashboard/logic/dashboard_logic.dart
+++ b/lib/features/dashboard/logic/dashboard_logic.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 
 import 'package:hive/hive.dart';
+import 'package:intl/intl.dart';
+import 'package:personal_finance/utils/app_localization.dart';
 
 import 'package:personal_finance/features/dashboard/logic/dashboard_models.dart';
 import 'package:personal_finance/features/data/model/expense.dart';
@@ -234,14 +236,23 @@ class DashboardLogic extends ChangeNotifier {
           .toList();
 
   // Métodos para formateo de datos
-  String formatCurrency(double amount) => '\$${amount.toStringAsFixed(2)}';
+  String formatCurrency(double amount) =>
+      AppLocalizations(
+        Locale(Intl.getCurrentLocale()),
+      ).currencyFormatter.format(amount);
 
   String formatPercentage(double value, double total) {
     if (total == 0) return '0%';
-    return '${(value / total * 100).toStringAsFixed(0)}%';
+    final NumberFormat percentFormatter = NumberFormat.decimalPercentPattern(
+      locale: Intl.getCurrentLocale(),
+      decimalDigits: 0,
+    );
+    return percentFormatter.format(value / total);
   }
 
-  String formatDate(DateTime date) => '${date.day}/${date.month}/${date.year}';
+  String formatDate(DateTime date) => AppLocalizations(
+        Locale(Intl.getCurrentLocale()),
+      ).formatDate(date);
 
   // Métodos para validaciones
   bool get shouldShowExpensesChart =>

--- a/lib/features/dashboard/page/dashboard_page.dart
+++ b/lib/features/dashboard/page/dashboard_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:personal_finance/features/dashboard/logic/dashboard_logic.dart';
 import 'package:personal_finance/features/dashboard/page/dashboard_layout.dart';
 import 'package:personal_finance/features/dashboard/widgets/add_transaction_button.dart';
+import 'package:personal_finance/utils/app_localization.dart';
 import 'package:provider/provider.dart';
 
 class DashboardPage extends StatelessWidget {
@@ -12,9 +13,9 @@ class DashboardPage extends StatelessWidget {
     create: (BuildContext context) => DashboardLogic(),
     child: Scaffold(
       appBar: AppBar(
-        title: const Hero(
+        title: Hero(
           tag: 'start-button',
-          child: Text('Finanzas Personales'),
+          child: Text(AppLocalizations.of(context)!.appTitle),
         ),
         centerTitle: true,
         elevation: 0,

--- a/lib/features/dashboard/widgets/add_expense_modal.dart
+++ b/lib/features/dashboard/widgets/add_expense_modal.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:personal_finance/features/dashboard/logic/dashboard_logic.dart';
+import 'package:personal_finance/utils/app_localization.dart';
 import 'package:provider/provider.dart';
 
 class AddExpenseModal extends StatefulWidget {
@@ -171,7 +172,7 @@ class _AddExpenseModalState extends State<AddExpenseModal> {
                     }
                   },
                   icon: const Icon(Icons.check_circle),
-                  label: const Text('Agregar Gasto'),
+                  label: Text(AppLocalizations.of(context)!.addExpense),
                   style: ElevatedButton.styleFrom(
                     padding: const EdgeInsets.symmetric(vertical: 16),
                     backgroundColor: Colors.red,
@@ -271,7 +272,7 @@ class _AddExpenseModalState extends State<AddExpenseModal> {
                     Navigator.pop(context);
                   }
                 },
-                child: const Text('Agregar Gasto'),
+                child: Text(AppLocalizations.of(context)!.addExpense),
               ),
             ],
           ),

--- a/lib/features/dashboard/widgets/add_income_modal.dart
+++ b/lib/features/dashboard/widgets/add_income_modal.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:personal_finance/features/dashboard/logic/dashboard_logic.dart';
+import 'package:personal_finance/utils/app_localization.dart';
 import 'package:provider/provider.dart';
 
 /// Modal para agregar un nuevo ingreso.
@@ -176,7 +177,7 @@ class _AddIncomeModalState extends State<AddIncomeModal> {
                     }
                   },
                   icon: const Icon(Icons.check_circle),
-                  label: const Text('Agregar Ingreso'),
+                  label: Text(AppLocalizations.of(context)!.addIncome),
                   style: ElevatedButton.styleFrom(
                     padding: const EdgeInsets.symmetric(vertical: 16),
                     backgroundColor: Colors.green,

--- a/lib/features/dashboard/widgets/add_transaction_button.dart
+++ b/lib/features/dashboard/widgets/add_transaction_button.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import 'package:personal_finance/features/dashboard/widgets/add_transaction_modal.dart';
+import 'package:personal_finance/utils/app_localization.dart';
 
 /// Botón flotante para agregar nuevas transacciones (gastos o ingresos).
 /// 
@@ -21,6 +22,6 @@ class AddTransactionButton extends StatelessWidget {
           builder: (BuildContext context) => const AddTransactionModal(),
         ),
     icon: const Icon(Icons.add),
-    label: const Text('Agregar'),
+    label: Text(AppLocalizations.of(context)!.add),
   );
 }

--- a/lib/features/dashboard/widgets/balance_card.dart
+++ b/lib/features/dashboard/widgets/balance_card.dart
@@ -49,7 +49,7 @@ class BalanceCard extends StatelessWidget {
                 ),
                 const SizedBox(width: 12),
                 Text(
-                  'BALANCE TOTAL',
+                  AppLocalizations.of(context)!.totalBalance,
                   style: TextStyle(
                     fontWeight: FontWeight.bold,
                     fontSize: 16,
@@ -85,7 +85,9 @@ class BalanceCard extends StatelessWidget {
                 border: Border.all(color: balanceColor.withAlpha(50)),
               ),
               child: Text(
-                isPositive ? 'Saldo Positivo' : 'Saldo Negativo',
+                isPositive
+                    ? AppLocalizations.of(context)!.positiveBalance
+                    : AppLocalizations.of(context)!.negativeBalance,
                 style: TextStyle(
                   fontSize: 12,
                   fontWeight: FontWeight.w600,

--- a/lib/features/home.dart
+++ b/lib/features/home.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 
 import 'package:personal_finance/utils/routes/route_path.dart';
+import 'package:personal_finance/utils/app_localization.dart';
 
 class MyHomePage extends StatelessWidget {
   const MyHomePage({super.key});
@@ -15,7 +16,7 @@ class MyHomePage extends StatelessWidget {
           child: Column(
             mainAxisAlignment: MainAxisAlignment.center,
             children: <Widget>[
-              _buildWelcomeCard(theme),
+              _buildWelcomeCard(context, theme),
               const SizedBox(height: 40),
               _buildStartButton(context),
             ],
@@ -25,7 +26,7 @@ class MyHomePage extends StatelessWidget {
     );
   }
 
-  Widget _buildWelcomeCard(ThemeData theme) => Card(
+  Widget _buildWelcomeCard(BuildContext context, ThemeData theme) => Card(
       elevation: 4,
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
       child: Padding(
@@ -35,7 +36,7 @@ class MyHomePage extends StatelessWidget {
             Icon(Icons.savings, size: 64, color: theme.colorScheme.primary),
             const SizedBox(height: 16),
             Text(
-              'Bienvenido a tu app de finanzas personales!',
+              AppLocalizations.of(context)!.welcome,
               style: theme.textTheme.headlineSmall?.copyWith(
                 fontWeight: FontWeight.bold,
               ),
@@ -59,9 +60,9 @@ class MyHomePage extends StatelessWidget {
           ),
           elevation: 6,
         ),
-        child: const Text(
-          'Iniciar',
-          style: TextStyle(
+        child: Text(
+          AppLocalizations.of(context)!.start,
+          style: const TextStyle(
             fontSize: 20,
             fontWeight: FontWeight.bold,
             color: Colors.white,

--- a/lib/features/onboarding/onboarding_page.dart
+++ b/lib/features/onboarding/onboarding_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:personal_finance/utils/routes/route_path.dart';
+import 'package:personal_finance/utils/app_localization.dart';
 
 class OnboardingPage extends StatefulWidget {
   const OnboardingPage({super.key});
@@ -12,10 +13,10 @@ class _OnboardingPageState extends State<OnboardingPage> {
   final PageController _controller = PageController();
   int _index = 0;
 
-  final List<_OnboardStep> _steps = const <_OnboardStep>[
-    _OnboardStep(title: 'Registra tus gastos', description: 'Añade transacciones de forma rápida y sencilla.'),
-    _OnboardStep(title: 'Visualiza tu progreso', description: 'Consulta tu balance diario, semanal o mensual.'),
-    _OnboardStep(title: 'Aprende consejos', description: 'Recibe tips financieros personalizados cada día.'),
+  final List<_OnboardStep> _steps = <_OnboardStep>[
+    const _OnboardStep(titleKey: 'step1Title', descriptionKey: 'step1Desc'),
+    const _OnboardStep(titleKey: 'step2Title', descriptionKey: 'step2Desc'),
+    const _OnboardStep(titleKey: 'step3Title', descriptionKey: 'step3Desc'),
   ];
 
   @override
@@ -37,9 +38,11 @@ class _OnboardingPageState extends State<OnboardingPage> {
                         children: <Widget>[
                           Icon(Icons.savings, size: 80, color: Theme.of(context).colorScheme.primary),
                           const SizedBox(height: 20),
-                          Text(step.title, style: Theme.of(context).textTheme.headlineSmall, textAlign: TextAlign.center),
+                          Text(AppLocalizations.of(context)!.translate(step.titleKey),
+                              style: Theme.of(context).textTheme.headlineSmall,
+                              textAlign: TextAlign.center),
                           const SizedBox(height: 12),
-                          Text(step.description, textAlign: TextAlign.center),
+                          Text(AppLocalizations.of(context)!.translate(step.descriptionKey), textAlign: TextAlign.center),
                         ],
                       ),
                     );
@@ -55,7 +58,7 @@ class _OnboardingPageState extends State<OnboardingPage> {
                         onPressed: () {
                           _controller.previousPage(duration: const Duration(milliseconds: 300), curve: Curves.easeInOut);
                         },
-                        child: const Text('Atrás'),
+                        child: Text(AppLocalizations.of(context)!.back),
                       ),
                     const Spacer(),
                     ElevatedButton(
@@ -66,7 +69,9 @@ class _OnboardingPageState extends State<OnboardingPage> {
                           _controller.nextPage(duration: const Duration(milliseconds: 300), curve: Curves.easeInOut);
                         }
                       },
-                      child: Text(_index == _steps.length - 1 ? 'Comenzar' : 'Siguiente'),
+                      child: Text(_index == _steps.length - 1
+                          ? AppLocalizations.of(context)!.getStarted
+                          : AppLocalizations.of(context)!.next),
                     )
                   ],
                 ),
@@ -78,7 +83,7 @@ class _OnboardingPageState extends State<OnboardingPage> {
 }
 
 class _OnboardStep {
-  final String title;
-  final String description;
-  const _OnboardStep({required this.title, required this.description});
+  final String titleKey;
+  final String descriptionKey;
+  const _OnboardStep({required this.titleKey, required this.descriptionKey});
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,9 @@
+import 'dart:ui' as ui;
+
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
 import 'package:hive_flutter/hive_flutter.dart';
+import 'package:intl/intl.dart';
 import 'package:personal_finance/features/data/model/expense.dart';
 import 'package:personal_finance/features/data/model/income.dart';
 import 'package:personal_finance/utils/app.dart';
@@ -8,6 +11,10 @@ import 'package:personal_finance/utils/injection_container.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
+
+  // Establece la configuración regional predeterminada según el dispositivo
+  final Locale deviceLocale = ui.PlatformDispatcher.instance.locale;
+  Intl.defaultLocale = deviceLocale.toLanguageTag();
 
   // Inicializa Hive
   await Hive.initFlutter();

--- a/lib/utils/app.dart
+++ b/lib/utils/app.dart
@@ -29,7 +29,8 @@ class MyApp extends StatelessWidget {
         ChangeNotifierProvider<TipProvider>(create: (_) => TipProvider()),
       ],
       child: MaterialApp(
-        title: 'Finanzas Personales',
+        onGenerateTitle: (BuildContext context) =>
+            AppLocalizations.of(context)!.appTitle,
         debugShowCheckedModeBanner: false,
         theme: _buildLightTheme(),
         darkTheme: _buildDarkTheme(),
@@ -46,7 +47,7 @@ class MyApp extends StatelessWidget {
           Locale('es', 'MX'),
           Locale('en', 'US'),
         ],
-        locale: const Locale('es', 'GT'),
+        locale: WidgetsBinding.instance.platformDispatcher.locale,
       ),
     );
 

--- a/lib/utils/app_localization.dart
+++ b/lib/utils/app_localization.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-
 import 'package:intl/intl.dart';
 
 class AppLocalizations {
@@ -8,27 +7,97 @@ class AppLocalizations {
 
   AppLocalizations(this.locale);
 
-  static AppLocalizations? of(BuildContext context) => Localizations.of<AppLocalizations>(context, AppLocalizations);
+  static AppLocalizations? of(BuildContext context) =>
+      Localizations.of<AppLocalizations>(context, AppLocalizations);
 
   static const LocalizationsDelegate<AppLocalizations> delegate =
       _AppLocalizationsDelegate();
 
-  String get currencySymbol {
-    switch (locale.countryCode) {
-      case 'GT':
-        return 'Q'; // Quetzal guatemalteco
-      case 'US':
-        return '\$'; // Dólar estadounidense
-      case 'MX':
-        return '\$'; // Peso mexicano
-      case 'ES':
-        return '€'; // Euro
-      default:
-        return '\$'; // Símbolo por defecto
-    }
-  }
+  static const Map<String, Map<String, String>> _localizedValues = <String, Map<String, String>>{
+    'en': <String, String>{
+      'welcome': 'Welcome to your personal finance app!',
+      'start': 'Start',
+      'appTitle': 'Personal Finance',
+      'back': 'Back',
+      'next': 'Next',
+      'getStarted': 'Get Started',
+      'signInToContinue': 'Sign in to continue',
+      'continueWithGoogle': 'Continue with Google',
+      'continueWithApple': 'Continue with Apple',
+      'totalBalance': 'TOTAL BALANCE',
+      'positiveBalance': 'Positive Balance',
+      'negativeBalance': 'Negative Balance',
+      'add': 'Add',
+      'addIncome': 'Add Income',
+      'addExpense': 'Add Expense',
+      'step1Title': 'Track your expenses',
+      'step1Desc': 'Add transactions quickly and easily.',
+      'step2Title': 'See your progress',
+      'step2Desc': 'Check your daily, weekly or monthly balance.',
+      'step3Title': 'Learn tips',
+      'step3Desc': 'Get personalized financial advice every day.',
+    },
+    'es': <String, String>{
+      'welcome': '¡Bienvenido a tu app de finanzas personales!',
+      'start': 'Iniciar',
+      'appTitle': 'Finanzas Personales',
+      'back': 'Atrás',
+      'next': 'Siguiente',
+      'getStarted': 'Comenzar',
+      'signInToContinue': 'Inicia sesión para continuar',
+      'continueWithGoogle': 'Continuar con Google',
+      'continueWithApple': 'Continuar con Apple',
+      'totalBalance': 'BALANCE TOTAL',
+      'positiveBalance': 'Saldo Positivo',
+      'negativeBalance': 'Saldo Negativo',
+      'add': 'Agregar',
+      'addIncome': 'Agregar Ingreso',
+      'addExpense': 'Agregar Gasto',
+      'step1Title': 'Registra tus gastos',
+      'step1Desc': 'Añade transacciones de forma rápida y sencilla.',
+      'step2Title': 'Visualiza tu progreso',
+      'step2Desc': 'Consulta tu balance diario, semanal o mensual.',
+      'step3Title': 'Aprende consejos',
+      'step3Desc': 'Recibe tips financieros personalizados cada día.',
+    },
+  };
 
-  NumberFormat get currencyFormatter => NumberFormat.currency(symbol: currencySymbol, decimalDigits: 2);
+  String _text(String key) =>
+      _localizedValues[locale.languageCode]?[key] ?? _localizedValues['es']![key]!;
+
+  /// Returns the localized string for the given [key].
+  String translate(String key) => _text(key);
+
+  String get welcome => _text('welcome');
+  String get start => _text('start');
+  String get appTitle => _text('appTitle');
+  String get back => _text('back');
+  String get next => _text('next');
+  String get getStarted => _text('getStarted');
+  String get signInToContinue => _text('signInToContinue');
+  String get continueWithGoogle => _text('continueWithGoogle');
+  String get continueWithApple => _text('continueWithApple');
+  String get totalBalance => _text('totalBalance');
+  String get positiveBalance => _text('positiveBalance');
+  String get negativeBalance => _text('negativeBalance');
+  String get add => _text('add');
+  String get addIncome => _text('addIncome');
+  String get addExpense => _text('addExpense');
+  String get step1Title => _text('step1Title');
+  String get step1Desc => _text('step1Desc');
+  String get step2Title => _text('step2Title');
+  String get step2Desc => _text('step2Desc');
+  String get step3Title => _text('step3Title');
+  String get step3Desc => _text('step3Desc');
+
+  NumberFormat get currencyFormatter =>
+      NumberFormat.simpleCurrency(locale: locale.toLanguageTag());
+
+  NumberFormat get decimalFormatter =>
+      NumberFormat.decimalPattern(locale.toLanguageTag());
+
+  String formatDate(DateTime date) =>
+      DateFormat.yMd(locale.toLanguageTag()).format(date);
 }
 
 class _AppLocalizationsDelegate
@@ -39,7 +108,8 @@ class _AppLocalizationsDelegate
   bool isSupported(Locale locale) => <String>['en', 'es'].contains(locale.languageCode);
 
   @override
-  Future<AppLocalizations> load(Locale locale) => SynchronousFuture<AppLocalizations>(AppLocalizations(locale));
+  Future<AppLocalizations> load(Locale locale) =>
+      SynchronousFuture<AppLocalizations>(AppLocalizations(locale));
 
   @override
   bool shouldReload(_AppLocalizationsDelegate old) => false;

--- a/lib/utils/widgets/drawer.dart
+++ b/lib/utils/widgets/drawer.dart
@@ -2,6 +2,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
 import 'package:intl/intl.dart';
+import 'package:personal_finance/utils/app_localization.dart';
 
 class CustomDrawer extends StatelessWidget {
   const CustomDrawer({
@@ -335,13 +336,13 @@ class CustomDrawer extends StatelessWidget {
     );
   }
 
-  Widget _buildFooter(BuildContext context, bool isIOS) => const Padding(
-      padding: EdgeInsets.all(16),
-      child: Text(
-        'Finanzas Personales v1.0',
-        style: TextStyle(fontSize: 12, color: Colors.grey),
-      ),
-    );
+  Widget _buildFooter(BuildContext context, bool isIOS) => Padding(
+        padding: const EdgeInsets.all(16),
+        child: Text(
+          '${AppLocalizations.of(context)!.appTitle} v1.0',
+          style: const TextStyle(fontSize: 12, color: Colors.grey),
+        ),
+      );
 
   void _navigateTo(BuildContext context, String routeName) {
     Navigator.pop(context);


### PR DESCRIPTION
## Summary
- detect device locale and set default language
- localize app title and menu footer
- add comprehensive `AppLocalizations` helper with translations for English and Spanish
- update pages and widgets to use localized strings
- format currency, percentages and dates according to locale

## Testing
- `flutter test -r expanded` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875eab1c248832fbe39e046553892b0