### PR TITLE
Add platform-specific auth

### DIFF
--- a/lib/features/auth/data/firebase_auth_service.dart
+++ b/lib/features/auth/data/firebase_auth_service.dart
@@ -15,10 +15,13 @@ class FirebaseAuthService implements AuthDataSource {
   @override
   Future<User?> signInWithGoogle() async {
     try {
-      await GoogleSignIn.instance.initialize(serverClientId: 'TU_SERVER_CLIENT_ID');
-      final GoogleSignInAccount googleUser = await GoogleSignIn.instance.authenticate();
-      final GoogleSignInAuthentication googleAuth = googleUser.authentication;
+      final GoogleSignInAccount? googleUser = await GoogleSignIn().signIn();
+      if (googleUser == null) {
+        throw Exception('Inicio de sesión cancelado');
+      }
+      final GoogleSignInAuthentication googleAuth = await googleUser.authentication;
       final OAuthCredential credential = GoogleAuthProvider.credential(
+        accessToken: googleAuth.accessToken,
         idToken: googleAuth.idToken,
       );
       final UserCredential userCredential = await _auth.signInWithCredential(credential);

--- a/lib/features/auth/logic/auth_provider.dart
+++ b/lib/features/auth/logic/auth_provider.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 
 import 'package:personal_finance/features/auth/domain/auth_repository.dart';
@@ -16,6 +18,10 @@ class AuthProvider extends ChangeNotifier {
   Future<bool> signInWithGoogle() async {
     _setLoading(true);
     try {
+      if (!Platform.isAndroid) {
+        throw Exception('Google Sign-In no soportado en esta plataforma');
+      }
+      await authRepository.signInWithGoogle();
       _setLoading(false);
       _setError(null);
       return true;
@@ -29,6 +35,9 @@ class AuthProvider extends ChangeNotifier {
   Future<bool> signInWithApple() async {
     _setLoading(true);
     try {
+      if (!Platform.isIOS) {
+        throw Exception('Sign in with Apple no soportado en esta plataforma');
+      }
       await authRepository.signInWithApple();
       _setLoading(false);
       _setError(null);

--- a/lib/features/auth/widgets/social_buttons.dart
+++ b/lib/features/auth/widgets/social_buttons.dart
@@ -23,15 +23,15 @@ class SocialLoginButtons extends StatelessWidget {
         }
         return Column(
           children: <Widget>[
-            SizedBox(
-              width: double.infinity,
-              child: ElevatedButton.icon(
-                icon: const Icon(Icons.g_mobiledata),
-                label: const Text('Continuar con Google'),
-                onPressed:
-                    provider.isLoading
-                        ? null
-                        : () async {
+            if (Platform.isAndroid)
+              SizedBox(
+                width: double.infinity,
+                child: ElevatedButton.icon(
+                  icon: const Icon(Icons.g_mobiledata),
+                  label: const Text('Continuar con Google'),
+                  onPressed: provider.isLoading
+                      ? null
+                      : () async {
                           final bool success =
                               await provider.signInWithGoogle();
                           if (success && context.mounted) {
@@ -41,8 +41,8 @@ class SocialLoginButtons extends StatelessWidget {
                             );
                           }
                         },
+                ),
               ),
-            ),
             if (Platform.isIOS) ...<Widget>[
               const SizedBox(height: 12),
               SizedBox(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,6 +5,7 @@ import 'package:personal_finance/features/data/model/expense.dart';
 import 'package:personal_finance/features/data/model/income.dart';
 import 'package:personal_finance/utils/app.dart';
 import 'package:personal_finance/utils/injection_container.dart';
+import 'firebase_options.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -16,8 +17,10 @@ Future<void> main() async {
   Hive.registerAdapter(IncomeAdapter());
   await Hive.openBox<Income>('incomes');
 
-  // Inicializa Firebase
-  await Firebase.initializeApp();
+  // Inicializa Firebase con opciones por plataforma
+  await Firebase.initializeApp(
+    options: DefaultFirebaseOptions.currentPlatform,
+  );
 
   // Configura dependencias
   await initDependencies();


### PR DESCRIPTION
## Summary
- initialize firebase with current platform options
- implement Google and Apple login in `AuthProvider`
- add platform checks and show proper buttons
- implement Google sign-in flow in `FirebaseAuthService`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875f26f1000832f8bed8f2df3af4b6e