### PR TITLE
Improve dashboard filters

### DIFF
--- a/lib/features/dashboard/logic/dashboard_models.dart
+++ b/lib/features/dashboard/logic/dashboard_models.dart
@@ -6,6 +6,7 @@ enum PeriodFilter {
   semana,
   mes,
   anio,
+  personalizado,
 }
 
 /// Datos para el gráfico

--- a/lib/features/dashboard/page/dashboard_layout.dart
+++ b/lib/features/dashboard/page/dashboard_layout.dart
@@ -4,10 +4,13 @@ import 'package:personal_finance/features/dashboard/logic/dashboard_logic.dart';
 import 'package:personal_finance/features/dashboard/logic/dashboard_models.dart';
 import 'package:personal_finance/features/dashboard/widgets/balance_card.dart';
 import 'package:personal_finance/features/dashboard/widgets/periodic_selector.dart';
+import 'package:personal_finance/features/dashboard/widgets/category_selector.dart';
 import 'package:personal_finance/features/data/model/expense.dart';
 import 'package:personal_finance/features/data/model/income.dart';
 import 'package:provider/provider.dart';
 import 'package:syncfusion_flutter_charts/charts.dart';
+
+void _noop(String _) {}
 
 class DashboardLayout extends StatelessWidget {
   const DashboardLayout({super.key});
@@ -62,13 +65,12 @@ class DashboardLayout extends StatelessWidget {
                         children: <Widget>[
                           BalanceCard(balance: logic.balance),
                           const SizedBox(height: 16),
-                          PeriodSelector(
-                            selected: logic.selectedPeriod.name,
-                            onSelect: (String value) {
-                              final PeriodFilter period = PeriodFilter.values.firstWhere((PeriodFilter e) => e.name == value);
-                              logic.changePeriod(period);
-                            },
+                          const PeriodSelector(
+                            selected: '',
+                            onSelect: _noop,
                           ),
+                          const SizedBox(height: 8),
+                          const CategorySelector(),
                           const SizedBox(height: 16),
                           _buildSummaryCards(logic),
                           const SizedBox(height: 16),

--- a/lib/features/dashboard/widgets/category_selector.dart
+++ b/lib/features/dashboard/widgets/category_selector.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+import 'package:personal_finance/features/dashboard/logic/dashboard_logic.dart';
+import 'package:provider/provider.dart';
+
+class CategorySelector extends StatelessWidget {
+  const CategorySelector({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final DashboardLogic logic = context.watch<DashboardLogic>();
+    final List<String> categories = logic.availableCategories;
+    final String selected = logic.selectedCategory ?? 'Todas';
+
+    return DropdownButton<String>(
+      value: selected,
+      items: categories
+          .map((String cat) => DropdownMenuItem<String>(
+                value: cat,
+                child: Text(cat),
+              ))
+          .toList(),
+      onChanged: (String? value) {
+        if (value != null) {
+          logic.changeCategory(value);
+        }
+      },
+    );
+  }
+}
+

--- a/lib/features/dashboard/widgets/periodic_selector.dart
+++ b/lib/features/dashboard/widgets/periodic_selector.dart
@@ -50,7 +50,25 @@ class PeriodSelector extends StatelessWidget {
                 ),
               ),
               selected: isSelected,
-              onSelected: (_) => logic.changePeriod(p),
+              onSelected: (_) async {
+                if (p == PeriodFilter.personalizado) {
+                  final DateTimeRange? picked = await showDateRangePicker(
+                    context: context,
+                    firstDate: DateTime(2000),
+                    lastDate: DateTime.now(),
+                    initialDateRange: logic.customPeriod ??
+                        DateTimeRange(
+                          start: DateTime.now().subtract(const Duration(days: 7)),
+                          end: DateTime.now(),
+                        ),
+                  );
+                  if (picked != null) {
+                    logic.changePeriod(p, range: picked);
+                  }
+                } else {
+                  logic.changePeriod(p);
+                }
+              },
               selectedColor: Colors.blue,
               backgroundColor: Colors.white,
               side: BorderSide(
@@ -77,6 +95,8 @@ class PeriodSelector extends StatelessWidget {
         return 'Mes';
       case PeriodFilter.anio:
         return 'Año';
+      case PeriodFilter.personalizado:
+        return 'Período';
     }
   }
 }


### PR DESCRIPTION
## Summary
- add new `personalizado` option for period filtering
- support custom date ranges in `DashboardLogic` and widget
- add category filtering support
- implement `CategorySelector` widget
- wire up new controls on dashboard layout

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875f5ae52d8832fb81925ae258e2418