### PR TITLE
Fix drawer navigation to prevent duplicate HomePage

### DIFF
--- a/lib/utils/widgets/drawer.dart
+++ b/lib/utils/widgets/drawer.dart
@@ -347,6 +347,6 @@ class CustomDrawer extends StatelessWidget {
 
   void _navigateTo(BuildContext context, String routeName) {
     Navigator.pop(context);
-    Navigator.pushNamed(context, routeName);
+    Navigator.pushReplacementNamed(context, routeName);
   }
 }


### PR DESCRIPTION
## Summary
- ensure drawer navigation replaces the current route

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6885d99ecd30832fa53acfbd7b90e6ad