### PR TITLE
Add basic screens for reports, alerts and profile

### DIFF
--- a/lib/features/alerts/alert_item.dart
+++ b/lib/features/alerts/alert_item.dart
@@ -1,0 +1,11 @@
+class AlertItem {
+  final String title;
+  final String description;
+  final DateTime date;
+
+  AlertItem({
+    required this.title,
+    required this.description,
+    required this.date,
+  });
+}

--- a/lib/features/alerts/alerts_provider.dart
+++ b/lib/features/alerts/alerts_provider.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+
+import 'alert_item.dart';
+
+class AlertsProvider extends ChangeNotifier {
+  final List<AlertItem> _alerts = <AlertItem>[
+    AlertItem(
+      title: 'Pago de tarjeta',
+      description: 'La fecha límite es el 5 de cada mes.',
+      date: DateTime.now(),
+    ),
+    AlertItem(
+      title: 'Recordatorio de ahorro',
+      description: 'Ahorra al menos el 10% de tu salario.',
+      date: DateTime.now(),
+    ),
+  ];
+
+  List<AlertItem> get alerts => List.unmodifiable(_alerts);
+}

--- a/lib/features/alerts/pages/alerts_page.dart
+++ b/lib/features/alerts/pages/alerts_page.dart
@@ -1,8 +1,32 @@
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import 'package:personal_finance/features/alerts/alert_item.dart';
+import 'package:personal_finance/features/alerts/alerts_provider.dart';
+import 'package:provider/provider.dart';
 
 class AlertsPage extends StatelessWidget {
   const AlertsPage({super.key});
 
   @override
-  Widget build(BuildContext context) => const Center(child: Text('Contenido de Alertas'));
+  Widget build(BuildContext context) => Consumer<AlertsProvider>(
+        builder: (BuildContext context, AlertsProvider provider, _) {
+          if (provider.alerts.isEmpty) {
+            return const Center(child: Text('Sin alertas por el momento'));
+          }
+          return ListView.separated(
+            padding: const EdgeInsets.all(16),
+            itemCount: provider.alerts.length,
+            itemBuilder: (BuildContext context, int index) {
+              final AlertItem alert = provider.alerts[index];
+              return ListTile(
+                leading: const Icon(Icons.notifications_active),
+                title: Text(alert.title),
+                subtitle: Text(alert.description),
+                trailing: Text(DateFormat('dd/MM').format(alert.date)),
+              );
+            },
+            separatorBuilder: (_, __) => const Divider(),
+          );
+        },
+      );
 }

--- a/lib/features/auth/logic/auth_provider.dart
+++ b/lib/features/auth/logic/auth_provider.dart
@@ -44,6 +44,18 @@ class AuthProvider extends ChangeNotifier {
     }
   }
 
+  Future<void> logout() async {
+    _setLoading(true);
+    try {
+      await authRepository.logout();
+      await LocalAuthService().logout();
+    } catch (e) {
+      _setError(e.toString());
+    } finally {
+      _setLoading(false);
+    }
+  }
+
   void clearError() {
     _setError(null);
   }

--- a/lib/features/profile/pages/profile_page.dart
+++ b/lib/features/profile/pages/profile_page.dart
@@ -1,8 +1,42 @@
 import 'package:flutter/material.dart';
+import 'package:personal_finance/features/auth/logic/auth_provider.dart';
+import 'package:personal_finance/utils/routes/route_path.dart';
+import 'package:provider/provider.dart';
 
 class ProfilePage extends StatelessWidget {
   const ProfilePage({super.key});
 
   @override
-  Widget build(BuildContext context) => const Center(child: Text('Contenido del Perfil'));
+  Widget build(BuildContext context) => Consumer<AuthProvider>(
+        builder: (BuildContext context, AuthProvider provider, _) => Padding(
+          padding: const EdgeInsets.all(24),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.start,
+            children: <Widget>[
+              const CircleAvatar(
+                radius: 40,
+                child: Icon(Icons.person, size: 40),
+              ),
+              const SizedBox(height: 12),
+              const Text('Usuario Invitado'),
+              const SizedBox(height: 24),
+              ElevatedButton.icon(
+                onPressed: provider.isLoading
+                    ? null
+                    : () async {
+                        await provider.logout();
+                        if (context.mounted) {
+                          Navigator.pushReplacementNamed(
+                            context,
+                            RoutePath.login,
+                          );
+                        }
+                      },
+                icon: const Icon(Icons.logout),
+                label: const Text('Cerrar sesión'),
+              ),
+            ],
+          ),
+        ),
+      );
 }

--- a/lib/features/reports/pages/reports_page.dart
+++ b/lib/features/reports/pages/reports_page.dart
@@ -1,8 +1,88 @@
 import 'package:flutter/material.dart';
+import 'package:personal_finance/features/dashboard/logic/dashboard_logic.dart';
+import 'package:personal_finance/features/dashboard/logic/dashboard_models.dart';
+import 'package:provider/provider.dart';
+import 'package:syncfusion_flutter_charts/charts.dart';
 
 class ReportsPage extends StatelessWidget {
   const ReportsPage({super.key});
 
+  Widget _buildSummary(String title, double amount, Color color) => Card(
+        elevation: 2,
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            children: <Widget>[
+              Text(title, style: const TextStyle(fontWeight: FontWeight.bold)),
+              const SizedBox(height: 8),
+              Text(
+                '\$${amount.toStringAsFixed(2)}',
+                style: TextStyle(color: color, fontSize: 16),
+              ),
+            ],
+          ),
+        ),
+      );
+
   @override
-  Widget build(BuildContext context) => const Center(child: Text('Contenido de Reportes'));
+  Widget build(BuildContext context) => Consumer<DashboardLogic>(
+        builder: (BuildContext context, DashboardLogic logic, _) {
+          if (!logic.hasData) {
+            return const Center(child: Text('Sin datos para mostrar'));
+          }
+          final List<ChartData> data = logic.getChartData();
+          return SingleChildScrollView(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              children: <Widget>[
+                Row(
+                  children: <Widget>[
+                    Expanded(
+                      child: _buildSummary('Ingresos', logic.totalIncomes, Colors.green),
+                    ),
+                    const SizedBox(width: 12),
+                    Expanded(
+                      child: _buildSummary('Gastos', logic.totalExpenses, Colors.red),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 24),
+                Card(
+                  elevation: 4,
+                  child: Padding(
+                    padding: const EdgeInsets.all(16),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: <Widget>[
+                        const Text(
+                          'Distribucion de gastos',
+                          style: TextStyle(
+                            fontWeight: FontWeight.bold,
+                            fontSize: 16,
+                          ),
+                        ),
+                        const SizedBox(height: 16),
+                        SizedBox(
+                          height: 200,
+                          child: SfCircularChart(
+                            series: <CircularSeries<ChartData, String>>[
+                              DoughnutSeries<ChartData, String>(
+                                dataSource: data,
+                                xValueMapper: (ChartData d, _) => d.category,
+                                yValueMapper: (ChartData d, _) => d.amount,
+                                pointColorMapper: (ChartData d, _) => d.color,
+                                dataLabelSettings: const DataLabelSettings(isVisible: true),
+                              ),
+                            ],
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          );
+        },
+      );
 }

--- a/lib/utils/app.dart
+++ b/lib/utils/app.dart
@@ -5,6 +5,7 @@ import 'package:personal_finance/features/auth/logic/auth_provider.dart';
 import 'package:personal_finance/features/dashboard/logic/dashboard_logic.dart';
 import 'package:personal_finance/features/navigation/navigation_provider.dart';
 import 'package:personal_finance/features/tips/tip_provider.dart';
+import 'package:personal_finance/features/alerts/alerts_provider.dart';
 import 'package:personal_finance/utils/app_localization.dart';
 import 'package:personal_finance/utils/injection_container.dart';
 import 'package:personal_finance/utils/routes/route_path.dart';
@@ -24,6 +25,7 @@ class MyApp extends StatelessWidget {
       ),
       ChangeNotifierProvider<DashboardLogic>(create: (_) => DashboardLogic()),
       ChangeNotifierProvider<TipProvider>(create: (_) => TipProvider()),
+      ChangeNotifierProvider<AlertsProvider>(create: (_) => AlertsProvider()),
       ChangeNotifierProvider<NavigationProvider>(
         create: (_) => NavigationProvider(),
       ),


### PR DESCRIPTION
## Summary
- create `AlertsProvider` and `AlertItem` model
- display list of alerts
- implement a simple reports page with summary and chart
- add logout functionality and profile UI
- register AlertsProvider in `MyApp`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6885dfbe63b0832f9ee78a0442c14895