### PR TITLE
Add profile page integration with Firebase

### DIFF
--- a/lib/features/auth/pages/register_page.dart
+++ b/lib/features/auth/pages/register_page.dart
@@ -1,6 +1,10 @@
 import 'package:flutter/material.dart';
 
 import 'package:personal_finance/features/auth/data/firebase_auth_service.dart';
+import 'package:personal_finance/features/profile/domain/profile_repository.dart';
+import 'package:personal_finance/features/profile/model/user_profile.dart';
+import 'package:personal_finance/utils/injection_container.dart';
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:personal_finance/utils/validators.dart';
 
 class RegisterPage extends StatefulWidget {
@@ -25,6 +29,7 @@ class _RegisterPageState extends State<RegisterPage> {
   bool isConfirmPasswordVisible = false;
 
   final FirebaseAuthService authService = FirebaseAuthService();
+  final ProfileRepository profileRepository = getIt<ProfileRepository>();
 
   Future<void> _selectBirthDate() async {
     final DateTime? pickedDate = await showDatePicker(
@@ -116,6 +121,19 @@ class _RegisterPageState extends State<RegisterPage> {
         emailController.text,
         passwordController.text,
       );
+
+      final String uid = FirebaseAuth.instance.currentUser!.uid;
+      await profileRepository.saveProfile(
+        UserProfile(
+          id: uid,
+          firstName: firstNameController.text,
+          lastName: lastNameController.text,
+          birthDate: DateTime.parse(birthDateController.text),
+          username: usernameController.text,
+          email: emailController.text,
+        ),
+      );
+
       Navigator.pushNamed(context, '/login');
     } catch (e) {
       ScaffoldMessenger.of(context).showSnackBar(

--- a/lib/features/profile/data/firebase_profile_service.dart
+++ b/lib/features/profile/data/firebase_profile_service.dart
@@ -1,0 +1,34 @@
+import 'dart:io';
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_storage/firebase_storage.dart';
+
+import '../domain/profile_datasource.dart';
+import '../model/user_profile.dart';
+
+class FirebaseProfileService implements ProfileDataSource {
+  final FirebaseFirestore _firestore = FirebaseFirestore.instance;
+  final FirebaseStorage _storage = FirebaseStorage.instance;
+
+  @override
+  Future<UserProfile?> getProfile(String uid) async {
+    final DocumentSnapshot<Map<String, dynamic>> doc =
+        await _firestore.collection('users').doc(uid).get();
+    if (doc.exists && doc.data() != null) {
+      return UserProfile.fromMap(doc.id, doc.data()!);
+    }
+    return null;
+  }
+
+  @override
+  Future<void> saveProfile(UserProfile profile) async {
+    await _firestore.collection('users').doc(profile.id).set(profile.toMap());
+  }
+
+  @override
+  Future<String> uploadProfilePicture(String uid, File image) async {
+    final Reference ref = _storage.ref().child('profile_pictures/$uid.jpg');
+    await ref.putFile(image);
+    return ref.getDownloadURL();
+  }
+}

--- a/lib/features/profile/domain/profile_datasource.dart
+++ b/lib/features/profile/domain/profile_datasource.dart
@@ -1,0 +1,9 @@
+import 'dart:io';
+
+import '../model/user_profile.dart';
+
+abstract class ProfileDataSource {
+  Future<void> saveProfile(UserProfile profile);
+  Future<UserProfile?> getProfile(String uid);
+  Future<String> uploadProfilePicture(String uid, File image);
+}

--- a/lib/features/profile/domain/profile_repository.dart
+++ b/lib/features/profile/domain/profile_repository.dart
@@ -1,0 +1,26 @@
+import 'dart:io';
+
+import '../model/user_profile.dart';
+import 'profile_datasource.dart';
+
+abstract class ProfileRepository {
+  Future<void> saveProfile(UserProfile profile);
+  Future<UserProfile?> getProfile(String uid);
+  Future<String> uploadProfilePicture(String uid, File image);
+}
+
+class ProfileRepositoryImpl implements ProfileRepository {
+  final ProfileDataSource dataSource;
+
+  ProfileRepositoryImpl(this.dataSource);
+
+  @override
+  Future<void> saveProfile(UserProfile profile) => dataSource.saveProfile(profile);
+
+  @override
+  Future<UserProfile?> getProfile(String uid) => dataSource.getProfile(uid);
+
+  @override
+  Future<String> uploadProfilePicture(String uid, File image) =>
+      dataSource.uploadProfilePicture(uid, image);
+}

--- a/lib/features/profile/logic/profile_provider.dart
+++ b/lib/features/profile/logic/profile_provider.dart
@@ -1,0 +1,44 @@
+import 'dart:io';
+
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/material.dart';
+
+import '../domain/profile_repository.dart';
+import '../model/user_profile.dart';
+
+class ProfileProvider extends ChangeNotifier {
+  ProfileProvider({required this.repository});
+
+  final ProfileRepository repository;
+
+  UserProfile? _profile;
+  bool _loading = false;
+
+  UserProfile? get profile => _profile;
+  bool get isLoading => _loading;
+
+  Future<void> loadProfile() async {
+    final User? user = FirebaseAuth.instance.currentUser;
+    if (user == null) return;
+    _setLoading(true);
+    _profile = await repository.getProfile(user.uid);
+    _setLoading(false);
+  }
+
+  Future<void> uploadPhoto(File image) async {
+    final User? user = FirebaseAuth.instance.currentUser;
+    if (user == null) return;
+    _setLoading(true);
+    final String url = await repository.uploadProfilePicture(user.uid, image);
+    if (_profile != null) {
+      _profile = _profile!.copyWith(photoUrl: url);
+      await repository.saveProfile(_profile!);
+    }
+    _setLoading(false);
+  }
+
+  void _setLoading(bool value) {
+    _loading = value;
+    notifyListeners();
+  }
+}

--- a/lib/features/profile/model/user_profile.dart
+++ b/lib/features/profile/model/user_profile.dart
@@ -1,0 +1,56 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+class UserProfile {
+  final String id;
+  final String firstName;
+  final String lastName;
+  final DateTime birthDate;
+  final String username;
+  final String email;
+  final String? photoUrl;
+
+  UserProfile({
+    required this.id,
+    required this.firstName,
+    required this.lastName,
+    required this.birthDate,
+    required this.username,
+    required this.email,
+    this.photoUrl,
+  });
+
+  factory UserProfile.fromMap(String id, Map<String, dynamic> map) {
+    return UserProfile(
+      id: id,
+      firstName: map['firstName'] ?? '',
+      lastName: map['lastName'] ?? '',
+      birthDate: (map['birthDate'] as Timestamp).toDate(),
+      username: map['username'] ?? '',
+      email: map['email'] ?? '',
+      photoUrl: map['photoUrl'] as String?,
+    );
+  }
+
+  Map<String, dynamic> toMap() {
+    return {
+      'firstName': firstName,
+      'lastName': lastName,
+      'birthDate': Timestamp.fromDate(birthDate),
+      'username': username,
+      'email': email,
+      'photoUrl': photoUrl,
+    };
+  }
+
+  UserProfile copyWith({String? photoUrl}) {
+    return UserProfile(
+      id: id,
+      firstName: firstName,
+      lastName: lastName,
+      birthDate: birthDate,
+      username: username,
+      email: email,
+      photoUrl: photoUrl ?? this.photoUrl,
+    );
+  }
+}

--- a/lib/features/profile/pages/profile_page.dart
+++ b/lib/features/profile/pages/profile_page.dart
@@ -1,31 +1,74 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
+import 'package:image_picker/image_picker.dart';
 import 'package:personal_finance/features/auth/logic/auth_provider.dart';
+import 'package:personal_finance/features/profile/logic/profile_provider.dart';
+import 'package:personal_finance/features/profile/domain/profile_repository.dart';
+import 'package:personal_finance/utils/injection_container.dart';
 import 'package:personal_finance/utils/routes/route_path.dart';
 import 'package:provider/provider.dart';
 
 class ProfilePage extends StatelessWidget {
   const ProfilePage({super.key});
 
+  Future<void> _pickImage(BuildContext context) async {
+    final ProfileProvider provider = context.read<ProfileProvider>();
+    final ImagePicker picker = ImagePicker();
+    final XFile? file = await picker.pickImage(source: ImageSource.gallery);
+    if (file != null) {
+      await provider.uploadPhoto(File(file.path));
+    }
+  }
+
   @override
-  Widget build(BuildContext context) => Consumer<AuthProvider>(
-    builder:
-        (BuildContext context, AuthProvider provider, _) => Padding(
-          padding: const EdgeInsets.all(24),
-          child: Column(
-            children: <Widget>[
-              const CircleAvatar(
-                radius: 40,
-                child: Icon(Icons.person, size: 40),
-              ),
-              const SizedBox(height: 12),
-              const Text('Usuario Invitado'),
-              const SizedBox(height: 24),
-              ElevatedButton.icon(
-                onPressed:
-                    provider.isLoading
-                        ? null
-                        : () async {
-                          await provider.logout();
+  Widget build(BuildContext context) => ChangeNotifierProvider<ProfileProvider>(
+        create: (_) {
+          final ProfileProvider provider = ProfileProvider(
+            repository: getIt<ProfileRepository>(),
+          );
+          provider.loadProfile();
+          return provider;
+        },
+        builder: (BuildContext context, _) =>
+            Consumer2<AuthProvider, ProfileProvider>(
+          builder: (
+            BuildContext context,
+            AuthProvider auth,
+            ProfileProvider profile,
+            _,
+          ) => Padding(
+            padding: const EdgeInsets.all(24),
+            child: Column(
+              children: <Widget>[
+                GestureDetector(
+                  onTap: () => _pickImage(context),
+                  child: CircleAvatar(
+                    radius: 40,
+                    backgroundImage: profile.profile?.photoUrl != null
+                        ? NetworkImage(profile.profile!.photoUrl!)
+                        : null,
+                    child: profile.profile?.photoUrl == null
+                        ? const Icon(Icons.person, size: 40)
+                        : null,
+                  ),
+                ),
+                const SizedBox(height: 12),
+                Text(
+                  profile.profile != null
+                      ? '${profile.profile!.firstName} ${profile.profile!.lastName}'
+                      : 'Usuario Invitado',
+                ),
+                if (profile.profile != null) ...<Widget>[
+                  const SizedBox(height: 4),
+                  Text(profile.profile!.email),
+                ],
+                const SizedBox(height: 24),
+                ElevatedButton.icon(
+                  onPressed: auth.isLoading
+                      ? null
+                      : () async {
+                          await auth.logout();
                           if (context.mounted) {
                             Navigator.pushReplacementNamed(
                               context,
@@ -33,11 +76,12 @@ class ProfilePage extends StatelessWidget {
                             );
                           }
                         },
-                icon: const Icon(Icons.logout),
-                label: const Text('Cerrar sesión'),
-              ),
-            ],
+                  icon: const Icon(Icons.logout),
+                  label: const Text('Cerrar sesión'),
+                ),
+              ],
+            ),
           ),
         ),
-  );
+      );
 }

--- a/lib/utils/injection_container.dart
+++ b/lib/utils/injection_container.dart
@@ -10,6 +10,9 @@ import 'package:personal_finance/features/data/repositories/transaction_reposito
 import 'package:personal_finance/features/domain/repositories/transaction_repository.dart';
 import 'package:personal_finance/features/domain/usecases/add_transaction_usecase.dart';
 import 'package:personal_finance/features/domain/usecases/get_dashboard_data_usecase.dart';
+import 'package:personal_finance/features/profile/data/firebase_profile_service.dart';
+import 'package:personal_finance/features/profile/domain/profile_datasource.dart';
+import 'package:personal_finance/features/profile/domain/profile_repository.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 final GetIt getIt = GetIt.instance;
@@ -30,6 +33,20 @@ Future<void> initDependencies() async {
   if (!getIt.isRegistered<AuthRepository>()) {
     getIt.registerLazySingleton<AuthRepository>(
       () => AuthRepositoryImpl(getIt<AuthDataSource>()),
+    );
+  }
+
+  // Profile DataSource
+  if (!getIt.isRegistered<ProfileDataSource>()) {
+    getIt.registerLazySingleton<ProfileDataSource>(
+      () => FirebaseProfileService(),
+    );
+  }
+
+  // Profile Repository
+  if (!getIt.isRegistered<ProfileRepository>()) {
+    getIt.registerLazySingleton<ProfileRepository>(
+      () => ProfileRepositoryImpl(getIt<ProfileDataSource>()),
     );
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,6 +31,8 @@ dependencies:
   firebase_core: ^3.13.0
   connectivity_plus: ^5.0.2
   cloud_firestore: ^5.6.11
+  firebase_storage: ^12.0.0
+  image_picker: ^1.1.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add Firebase Storage & image picker deps
- create profile model, datasource, repository, provider
- register profile dependencies
- save user profile during registration
- show profile details and upload picture

## Testing
- `flutter pub get` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68868f528f78832fbc2e1170b2f4ea8c