### PR TITLE
Add user-created alerts

### DIFF
--- a/lib/features/alerts/alert_item.dart
+++ b/lib/features/alerts/alert_item.dart
@@ -1,6 +1,16 @@
+import 'package:hive/hive.dart';
+
+part 'alert_item.g.dart';
+
+@HiveType(typeId: 2)
 class AlertItem {
+  @HiveField(0)
   final String title;
+
+  @HiveField(1)
   final String description;
+
+  @HiveField(2)
   final DateTime date;
 
   AlertItem({

--- a/lib/features/alerts/alert_item.g.dart
+++ b/lib/features/alerts/alert_item.g.dart
@@ -1,0 +1,47 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'alert_item.dart';
+
+// ***************************************************************************
+// TypeAdapterGenerator
+// ***************************************************************************
+
+class AlertItemAdapter extends TypeAdapter<AlertItem> {
+  @override
+  final int typeId = 2;
+
+  @override
+  AlertItem read(BinaryReader reader) {
+    final numOfFields = reader.readByte();
+    final fields = <int, dynamic>{
+      for (int i = 0; i < numOfFields; i++) reader.readByte(): reader.read(),
+    };
+    return AlertItem(
+      title: fields[0] as String,
+      description: fields[1] as String,
+      date: fields[2] as DateTime,
+    );
+  }
+
+  @override
+  void write(BinaryWriter writer, AlertItem obj) {
+    writer
+      ..writeByte(3)
+      ..writeByte(0)
+      ..write(obj.title)
+      ..writeByte(1)
+      ..write(obj.description)
+      ..writeByte(2)
+      ..write(obj.date);
+  }
+
+  @override
+  int get hashCode => typeId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is AlertItemAdapter &&
+          runtimeType == other.runtimeType &&
+          typeId == other.typeId;
+}

--- a/lib/features/alerts/alerts_provider.dart
+++ b/lib/features/alerts/alerts_provider.dart
@@ -1,20 +1,27 @@
 import 'package:flutter/material.dart';
+import 'package:hive/hive.dart';
 
 import 'alert_item.dart';
 
 class AlertsProvider extends ChangeNotifier {
-  final List<AlertItem> _alerts = <AlertItem>[
-    AlertItem(
-      title: 'Pago de tarjeta',
-      description: 'La fecha límite es el 5 de cada mes.',
-      date: DateTime.now(),
-    ),
-    AlertItem(
-      title: 'Recordatorio de ahorro',
-      description: 'Ahorra al menos el 10% de tu salario.',
-      date: DateTime.now(),
-    ),
-  ];
+  AlertsProvider() {
+    _loadAlerts();
+  }
+
+  final Box<AlertItem> _alertBox = Hive.box<AlertItem>('alerts');
+  final List<AlertItem> _alerts = <AlertItem>[];
 
   List<AlertItem> get alerts => List.unmodifiable(_alerts);
+
+  void _loadAlerts() {
+    _alerts
+      ..clear()
+      ..addAll(_alertBox.values);
+  }
+
+  Future<void> addAlert(AlertItem alert) async {
+    await _alertBox.add(alert);
+    _alerts.add(alert);
+    notifyListeners();
+  }
 }

--- a/lib/features/alerts/pages/alerts_page.dart
+++ b/lib/features/alerts/pages/alerts_page.dart
@@ -2,31 +2,50 @@ import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:personal_finance/features/alerts/alert_item.dart';
 import 'package:personal_finance/features/alerts/alerts_provider.dart';
+import 'package:personal_finance/features/alerts/widgets/add_alert_modal.dart';
 import 'package:provider/provider.dart';
 
 class AlertsPage extends StatelessWidget {
   const AlertsPage({super.key});
 
+  void _showAddAlertModal(BuildContext context) {
+    showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      builder: (BuildContext context) => const AddAlertModal(),
+    );
+  }
+
   @override
   Widget build(BuildContext context) => Consumer<AlertsProvider>(
-    builder: (BuildContext context, AlertsProvider provider, _) {
-      if (provider.alerts.isEmpty) {
-        return const Center(child: Text('Sin alertas por el momento'));
-      }
-      return ListView.separated(
-        padding: const EdgeInsets.all(16),
-        itemCount: provider.alerts.length,
-        itemBuilder: (BuildContext context, int index) {
-          final AlertItem alert = provider.alerts[index];
-          return ListTile(
-            leading: const Icon(Icons.notifications_active),
-            title: Text(alert.title),
-            subtitle: Text(alert.description),
-            trailing: Text(DateFormat('dd/MM').format(alert.date)),
-          );
-        },
-        separatorBuilder: (_, _) => const Divider(),
+        builder: (BuildContext context, AlertsProvider provider, _) => Stack(
+          children: <Widget>[
+            if (provider.alerts.isEmpty)
+              const Center(child: Text('Sin alertas por el momento'))
+            else
+              ListView.separated(
+                padding: const EdgeInsets.all(16),
+                itemCount: provider.alerts.length,
+                itemBuilder: (BuildContext context, int index) {
+                  final AlertItem alert = provider.alerts[index];
+                  return ListTile(
+                    leading: const Icon(Icons.notifications_active),
+                    title: Text(alert.title),
+                    subtitle: Text(alert.description),
+                    trailing: Text(DateFormat('dd/MM').format(alert.date)),
+                  );
+                },
+                separatorBuilder: (_, __) => const Divider(),
+              ),
+            Positioned(
+              bottom: 16,
+              right: 16,
+              child: FloatingActionButton(
+                onPressed: () => _showAddAlertModal(context),
+                child: const Icon(Icons.add),
+              ),
+            ),
+          ],
+        ),
       );
-    },
-  );
 }

--- a/lib/features/alerts/widgets/add_alert_modal.dart
+++ b/lib/features/alerts/widgets/add_alert_modal.dart
@@ -1,0 +1,112 @@
+import 'package:flutter/material.dart';
+import 'package:personal_finance/features/alerts/alert_item.dart';
+import 'package:personal_finance/features/alerts/alerts_provider.dart';
+import 'package:provider/provider.dart';
+
+class AddAlertModal extends StatefulWidget {
+  const AddAlertModal({super.key});
+
+  @override
+  State<AddAlertModal> createState() => _AddAlertModalState();
+}
+
+class _AddAlertModalState extends State<AddAlertModal> {
+  final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
+  final TextEditingController _titleController = TextEditingController();
+  final TextEditingController _descriptionController = TextEditingController();
+  DateTime _selectedDate = DateTime.now();
+
+  @override
+  Widget build(BuildContext context) {
+    final AlertsProvider provider = context.read<AlertsProvider>();
+    return Padding(
+      padding: EdgeInsets.only(
+        bottom: MediaQuery.of(context).viewInsets.bottom,
+        top: 16,
+        left: 16,
+        right: 16,
+      ),
+      child: SingleChildScrollView(
+        child: Form(
+          key: _formKey,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: <Widget>[
+              Container(
+                width: 50,
+                height: 5,
+                margin: const EdgeInsets.only(bottom: 16),
+                decoration: BoxDecoration(
+                  color: Colors.grey[300],
+                  borderRadius: BorderRadius.circular(10),
+                ),
+              ),
+              TextFormField(
+                controller: _titleController,
+                decoration: const InputDecoration(
+                  labelText: 'Título',
+                  border: OutlineInputBorder(),
+                ),
+                validator: (String? value) =>
+                    (value == null || value.isEmpty) ? 'Requerido' : null,
+              ),
+              const SizedBox(height: 16),
+              TextFormField(
+                controller: _descriptionController,
+                decoration: const InputDecoration(
+                  labelText: 'Descripción',
+                  border: OutlineInputBorder(),
+                ),
+                maxLines: 3,
+              ),
+              const SizedBox(height: 16),
+              Row(
+                children: <Widget>[
+                  Text(
+                    'Fecha: ${_selectedDate.day}/${_selectedDate.month}/${_selectedDate.year}',
+                    style: const TextStyle(fontWeight: FontWeight.bold),
+                  ),
+                  const Spacer(),
+                  TextButton.icon(
+                    onPressed: () async {
+                      final DateTime? pickedDate = await showDatePicker(
+                        context: context,
+                        initialDate: _selectedDate,
+                        firstDate: DateTime.now(),
+                        lastDate: DateTime(2100),
+                      );
+                      if (pickedDate != null) {
+                        setState(() => _selectedDate = pickedDate);
+                      }
+                    },
+                    icon: const Icon(Icons.calendar_today),
+                    label: const Text('Cambiar'),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 20),
+              SizedBox(
+                width: double.infinity,
+                child: ElevatedButton.icon(
+                  onPressed: () async {
+                    if (_formKey.currentState!.validate()) {
+                      final AlertItem alert = AlertItem(
+                        title: _titleController.text,
+                        description: _descriptionController.text,
+                        date: _selectedDate,
+                      );
+                      await provider.addAlert(alert);
+                      if (context.mounted) Navigator.of(context).pop();
+                    }
+                  },
+                  icon: const Icon(Icons.check_circle),
+                  label: const Text('Guardar'),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,6 +6,7 @@ import 'package:hive_flutter/hive_flutter.dart';
 import 'package:intl/intl.dart';
 import 'package:personal_finance/features/data/model/expense.dart';
 import 'package:personal_finance/features/data/model/income.dart';
+import 'package:personal_finance/features/alerts/alert_item.dart';
 import 'package:personal_finance/utils/app.dart';
 import 'package:personal_finance/utils/injection_container.dart';
 import 'package:personal_finance/utils/pending_action.dart';
@@ -25,6 +26,8 @@ Future<void> main() async {
   await Hive.openBox<Expense>('expenses');
   Hive.registerAdapter(IncomeAdapter());
   await Hive.openBox<Income>('incomes');
+  Hive.registerAdapter(AlertItemAdapter());
+  await Hive.openBox<AlertItem>('alerts');
   if (!Hive.isAdapterRegistered(0)) {
     Hive.registerAdapter(PendingActionAdapter());
   }

--- a/lib/utils/injection_container.dart
+++ b/lib/utils/injection_container.dart
@@ -6,6 +6,7 @@ import 'package:personal_finance/features/auth/domain/auth_repository.dart';
 import 'package:personal_finance/features/dashboard/logic/dashboard_logic_v2.dart';
 import 'package:personal_finance/features/data/model/expense.dart';
 import 'package:personal_finance/features/data/model/income.dart';
+import 'package:personal_finance/features/alerts/alert_item.dart';
 import 'package:personal_finance/features/data/repositories/transaction_repository_impl.dart';
 import 'package:personal_finance/features/domain/repositories/transaction_repository.dart';
 import 'package:personal_finance/features/domain/usecases/add_transaction_usecase.dart';
@@ -66,6 +67,12 @@ Future<void> initDependencies() async {
 
   if (!getIt.isRegistered<Box<Income>>()) {
     getIt.registerLazySingleton<Box<Income>>(() => Hive.box<Income>('incomes'));
+  }
+
+  if (!getIt.isRegistered<Box<AlertItem>>()) {
+    getIt.registerLazySingleton<Box<AlertItem>>(
+      () => Hive.box<AlertItem>('alerts'),
+    );
   }
 
   // Transaction Repository


### PR DESCRIPTION
## Summary
- enable persistence for alerts with Hive
- add UI modal to create new alerts
- show button on Alerts page to add alerts
- register alert box and adapter

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6886acef04d8832fa91670ef7fefe2f6